### PR TITLE
fix: fixed package.json types when using anything other than `"moduleResolution": "commonJs"`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/shiki.d.ts",
       "node": "./dist/shiki.node.mjs",
-      "default": "./dist/shiki.mjs",
-      "types": "./dist/shiki.d.ts"
+      "default": "./dist/shiki.mjs"
     },
     "./shiki/*": "./dist/shiki/*"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "node": "./dist/shiki.node.mjs",
-      "default": "./dist/shiki.mjs"
+      "default": "./dist/shiki.mjs",
+      "types": "./dist/shiki.d.ts"
     },
     "./shiki/*": "./dist/shiki/*"
   },


### PR DESCRIPTION
This is required when setting TypeScript's `moduleResolution` to anything other than `CommonJS`. For example, when set to `bundler` or `Node16`